### PR TITLE
Fix deploy health-check race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,4 +19,9 @@ jobs:
             git pull origin main
             uv sync
             sudo systemctl restart fwbng
-            curl -sf https://fwbng.exploratoryphilology.org > /dev/null || exit 1
+            for i in $(seq 1 10); do
+              curl -sf https://fwbng.exploratoryphilology.org > /dev/null && exit 0
+              sleep 2
+            done
+            echo "Health check failed after restart" >&2
+            exit 1


### PR DESCRIPTION
## Summary
- The deploy workflow's `curl` health check ran immediately after `systemctl restart fwbng`, before gunicorn finished coming back up, causing false-failure deploys
- Replaced the single check with a retry loop (up to 20s)

## Test plan
- [ ] Confirm workflow run succeeds end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)