### PR TITLE
Add explicit permissions block to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Closes CodeQL alert #5 (`actions/missing-workflow-permissions`)
- Adds `permissions: contents: read` to `.github/workflows/deploy.yml` — the minimal scope, since this workflow never calls the GitHub API (deploy happens over SSH to the droplet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)